### PR TITLE
Check spelling in UPPER_CASE_SEPARATED_BY_UNDERSCORE

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "https://github.com/aotaduy/eslint-plugin-spellcheck.git"
   },
+  "scripts": {
+    "test": "mocha"
+  },
   "author": "Andres Otaduy",
   "license": "MIT",
   "bugs": {

--- a/rules/spell-checker.js
+++ b/rules/spell-checker.js
@@ -41,7 +41,9 @@ module.exports = function(context) {
 
     function checkSpelling(aNode, value, spellingType) {
         if(!hasToSkip(value)) {
-            var nodeWords = value.replace(/[^a-zA-Z ]/g, ' ').replace(/([A-Z])/g, ' $1').toLowerCase().split(' ');
+            var nodeWords = value
+                .replace(/\b([A-Z][A-Z0-9_]*)\b/g, function(s) { return s.toLowerCase().split('_'); })
+                .replace(/[^a-zA-Z ]/g, ' ').replace(/([A-Z])/g, ' $1').toLowerCase().split(' ');
             nodeWords
                 .filter(function(aWord) {
                 return !lodash.includes(options.skipWords, aWord) && !spell.check(aWord);

--- a/test/spell-checker.js
+++ b/test/spell-checker.js
@@ -24,6 +24,9 @@ eslintTester.addRuleTest('rules/spell-checker', {
             code: 'var url = "http://examplus.com"',
             args:[2, {skipWords: ['url'], skipIfMatch:['http://[^\s]*']}]
         },
+        'var MY_ACTION = "MY_ACTION"',
+        'var MY_ACTION2 = "MY_ACTION2"',
+        'var a = 1 // This is MY_ACTION',
 
     ],
     invalid: [
@@ -91,6 +94,23 @@ eslintTester.addRuleTest('rules/spell-checker', {
             errors: [
                 { message: 'You have a misspelled word: color on Comment'},
                 { message: 'You have a misspelled word: behavior on Comment'}]
+        },
+        {
+            code: 'var MY_ACTOIN = "MY_ATCION"',
+            errors: [
+                { message: 'You have a misspelled word: actoin on Identifier'},
+                { message: 'You have a misspelled word: atcion on String'}]
+        },
+        {
+            code: 'var MY_ACTOIN2 = "MY_ATCION2"',
+            errors: [
+                { message: 'You have a misspelled word: actoin on Identifier'},
+                { message: 'You have a misspelled word: atcion on String'}]
+        },
+        {
+            code: 'var a = 1 // This is MY_ACTOIN',
+            errors: [
+                { message: 'You have a misspelled word: actoin on Comment'}]
         }
 
     ]


### PR DESCRIPTION
When using this plugin in my project, I found that upper case identifiers are not being spell checked. I'm using Redux in my project, and here it is a convention to name the actions with upper case, separated by underscore, like:
```
const MY_ACTION = "MY_ACTION";
```
I modified the checkSpelling function with a previous transformation to find tokens of the kind _UPPER_CASE_SEPARATED_BY_UNDERSCORE_ and convert to something like _upper case separated by underscore_, so the next step will be able to check these words. I added a few tests for these cases.

Additionally,  I added a test script to the package.json file to ease the test execution.
