### PR TITLE
Ignore file for npm pack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ coverage
 
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
+*.tgz
 
 # Dependency directory
 # Commenting this out is preferred by some people, see

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+node_modules
+test
+.eslintrc.json
+.travis.yml
+gulpfile.js


### PR DESCRIPTION
Fixes #27, but with minimal benefit since there are only two test files at the moment, 638 KB --> 636 KB