### PR TITLE
Add functions of String, JSON, Math

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,11 @@ build/Release
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git-
 node_modules
 
+# package-lock of npm >= 5.0.0
+# Should not be included for libraries
+# https://github.com/yarnpkg/yarn/issues/1583
+package-lock.json
+
 # Users Environment Variables
 .lock-wscript
 

--- a/rules/spell-checker.js
+++ b/rules/spell-checker.js
@@ -15,7 +15,10 @@ var spell = new Spellchecker(),
         lodash.keys(globals.mocha),
         lodash.keys(globals.jasmine),
         lodash.keys(globals.jquery),
-        lodash.keys(globals.shelljs)
+        lodash.keys(globals.shelljs),
+        Object.getOwnPropertyNames(String.prototype),
+        Object.getOwnPropertyNames(JSON),
+        Object.getOwnPropertyNames(Math)
     );
 
 module.exports = {

--- a/test/spell-checker.js
+++ b/test/spell-checker.js
@@ -30,6 +30,9 @@ ruleTester.run('spellcheck/spell-checker', rule, {
         'var a = "January"',
         'var a = \'Hello how are you this is a string\'',
         'var a = \'ArrayBuffer\'',
+        'var a = \'foobar\'.substring(0,1)',
+        'var a = JSON.stringify({})',
+        'var a = Math.trunc(-0.1)',
         {
             code: 'var url = "http://examplus.com"',
             options:[{skipWords: ['url'], skipIfMatch:['http://[^\s]*']}]


### PR DESCRIPTION
This PR will add the prototype-functions of `String`, `JSON` and `Math` to the `skipWords`-list.
This will reduce the false-negatives so users have to include less words into their own skipwords-list.

I added tests for each object-class.

I also set package-lock.json on gitignore like recommended in the commented url.