### PR TITLE
Make spell-checker rule compatible with ESLint 4+

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "coveralls": "^2.11.12",
-    "eslint": "^3.2.2",
+    "eslint": "^3.2.2 || ^4.0.0",
     "gulp": "^3.9.1",
     "gulp-istanbul": "1.0.0",
     "gulp-mocha": "^3.0.0",

--- a/rules/spell-checker.js
+++ b/rules/spell-checker.js
@@ -21,6 +21,11 @@ var spell = new Spellchecker(),
         Object.getOwnPropertyNames(Math)
     );
 
+// ESLint 3 had "eslint.version" in context. ESLint 4 does not have one.
+function isEslint4OrAbove(context) {
+  return !('eslint' in context);
+}
+
 module.exports = {
     // meta (object) contains metadata for the rule:
     meta: {
@@ -179,8 +184,21 @@ module.exports = {
                 });
         }
 
+        // Coverage exclusion only needed for ESLint<4
+        /* istanbul ignore next */
+        if (isEslint4OrAbove(context)) {
+          context
+            .getSourceCode()
+            .getAllComments()
+            .forEach(function (commentNode) {
+              checkComment(commentNode);
+            });
+        }
+
         return {
+            // Noop in ESLint 4+
             'BlockComment': checkComment,
+            // Noop in ESLint 4+
             'LineComment': checkComment,
             'Literal': checkLiteral,
             'TemplateElement': checkTemplateElement,


### PR DESCRIPTION
Fix #36 

Tests now pass both on ESLint 3.19 and 4.11
I focused on making it work in ESLint 4 rather than preparing dual testing env so this PR does not contain any solution for testing on 2 versions of ESLint.