### PR TITLE
CHANGE Array to Set for better performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ matrix:
 script:
   - npm run lint
   - npm test
+  - npm run performance

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "homepage": "https://github.com/sotaduy/eslint-plugin-spellcheck",
   "scripts": {
     "test": "gulp",
+    "performance": "gulp performance",
     "lint": "eslint -c .eslintrc.json rules/*.js"
   },
   "dependencies": {

--- a/rules/spell-checker.js
+++ b/rules/spell-checker.js
@@ -113,13 +113,13 @@ module.exports = {
         });
 
         spell.use(dictionary);
-        options.skipWords = lodash.union(options.skipWords, skipWords)
+        options.skipWords = new Set(lodash.union(options.skipWords, skipWords)
             .map(function (string) {
                 return string.toLowerCase();
-            });
+            }));
 
         function isSpellingError(aWord) {
-            return !lodash.includes(options.skipWords, aWord) && !spell.check(aWord);
+            return !options.skipWords.has(aWord) && !spell.check(aWord);
         }
 
         function checkSpelling(aNode, value, spellingType) {
@@ -173,7 +173,7 @@ module.exports = {
         }
         /* Returns true if the string in value has to be skipped for spell checking */
         function hasToSkip(value) {
-            return lodash.includes(options.skipWords, value) ||
+            return options.skipWords.has(value) ||
                 lodash.find(options.skipIfMatch, function (aPattern) {
                     return value.match(aPattern);
                 });


### PR DESCRIPTION
I switched out the Array to a `Set` which improves performance by 1/4. This is especially better when the skipWords-list gets very large like it did on my project.

before (with array):
4605ms
4607ms

after (wit Set):
3737ms
3698ms

I also added the performance-run to travis so we know that it will always work.