### PR TITLE
remove console.log of misspelled words

### DIFF
--- a/rules/spell-checker.js
+++ b/rules/spell-checker.js
@@ -154,7 +154,6 @@ module.exports = {
                         return splitByNumberWords.some(isSpellingError);
                     })
                     .forEach(function(aWord) {
-                      console.log(aWord);
                         context.report(
                             aNode,
                             'You have a misspelled word: {{word}} on {{spellingType}}', {


### PR DESCRIPTION
Because the misspelled word is reported back to ESLint, it shouldn't be necessary to additionally log it out to console. Since I'm using `/* eslint-disable spellcheck/spell-checker */` for several localized strings (font names in one case, country names in another), I don't get linter errors but I do get my console spammed with misspelled words.