### PR TITLE
fix for https://github.com/aotaduy/eslint-plugin-spellcheck/issues/45

### DIFF
--- a/rules/spell-checker.js
+++ b/rules/spell-checker.js
@@ -175,6 +175,10 @@ module.exports = {
                 }
             }
 
+        function isInImportDeclaration( aNode ) {
+          return aNode.parent && aNode.parent.type === 'ImportDeclaration';
+        }
+
         function checkComment(aNode) {
             if(options.comments) {
                 checkSpelling(aNode, aNode.value, 'Comment');
@@ -182,12 +186,12 @@ module.exports = {
         }
 
         function checkLiteral(aNode){
-            if(options.strings && typeof aNode.value === 'string') {
+            if(options.strings && typeof aNode.value === 'string' && !isInImportDeclaration(aNode)) {
                 checkSpelling(aNode, aNode.value, 'String');
             }
         }
         function checkTemplateElement(aNode){
-            if(options.templates && typeof aNode.value.raw === 'string') {
+            if(options.templates && typeof aNode.value.raw === 'string' && !isInImportDeclaration(aNode)) {
                 checkSpelling(aNode, aNode.value.raw, 'Template');
             }
         }

--- a/rules/spell-checker.js
+++ b/rules/spell-checker.js
@@ -176,7 +176,9 @@ module.exports = {
             }
 
         function isInImportDeclaration( aNode ) {
-          return aNode.parent && aNode.parent.type === 'ImportDeclaration';
+          // @see https://buildmedia.readthedocs.org/media/pdf/esprima/latest/esprima.pdf
+          return aNode.parent &&
+            (aNode.parent.type === 'ImportDeclaration' || aNode.parent.type === 'ExportDeclaration');
         }
 
         function checkComment(aNode) {

--- a/test/spell-checker.js
+++ b/test/spell-checker.js
@@ -12,6 +12,13 @@ var rule = require('../rules/spell-checker'),
 var ruleTester = new RuleTester({
     env: {
         'es6': true
+    },
+    ecmaFeatures: {
+      "modules": true
+    },
+    parserOptions: {
+      "ecmaVersion": 2018,
+      "sourceType": "module"
     }
 });
 
@@ -33,6 +40,9 @@ ruleTester.run('spellcheck/spell-checker', rule, {
         'var a = \'foobar\'.substring(0,1)',
         'var a = JSON.stringify({})',
         'var a = Math.trunc(-0.1)',
+        'import Foo from "component/Foo"',
+        'import { Foo } from "component/Foo"',
+        'export { Foo } from "component/Foo"',
         {
             code: 'var url = "http://examplus.com"',
             options:[{skipWords: ['url'], skipIfMatch:['http://[^\s]*']}]


### PR DESCRIPTION
Now while analyzing strings and template literals the plugin ignores module names of ES imports 
