### PR TITLE
TravisCI - Removes node 4; adds nodes 8, 10, and 12.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 sudo: false
 language: node_js
 node_js:
-  - "4.2"
   - "6"
+  - "8"
+  - "10"
+  - "12"
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
Removes Node 4.x -- seems to be failing with the latest devDependencies.

Adds Nodes 8.x, 10.x, & 12.x to TravisCI config.