### PR TITLE
Escaped apostrophes before checking for skipped words + performance enhancement

### DIFF
--- a/rules/spell-checker.js
+++ b/rules/spell-checker.js
@@ -220,14 +220,18 @@ module.exports = {
                 checkSpelling(aNode, aNode.name, 'Identifier');
             }
         }
+
         /* Returns true if the string in value has to be skipped for spell checking */
         function hasToSkip(value) {
-            return hasValueInSkipWords(value) ||
-                lodash.find(options.skipIfMatch, function (aPattern) {
-                    return value.match(aPattern);
-                });
-        }
+            if (hasValueInSkipWords(value))
+                return true;
 
+            const escapedValue = value.replace(/'/g, '\\\'');
+
+            return lodash.find(options.skipIfMatch, function (aPattern) {
+                return escapedValue.match(aPattern);
+            });
+        }
 
         /**
          * returns false if the word has to be skipped
@@ -235,12 +239,16 @@ module.exports = {
          * @return {Boolean} false if skip; true if not
          */
         function hasToSkipWord(word) {
-            if(word.length < options.minLength) return false;
-            if(lodash.find(options.skipWordIfMatch, function (aPattern) {
-                return word.match(aPattern);
-            })){
-                return false;
+            if (word.length < options.minLength) return false;
+
+            if (options.skipWordIfMatch) {
+                const escapedWord = word.replace(/'/g, '\\\'');
+
+                return !lodash.find(options.skipWordIfMatch, function (aPattern) {
+                    return escapedWord.match(aPattern);
+                });
             }
+
             return true;
         }
 

--- a/rules/spell-checker.js
+++ b/rules/spell-checker.js
@@ -16,13 +16,16 @@ function getGloabalsSkipsWords() {
 var spell = new Spellchecker(),
     dictionary = null,
     dictionaryLang,
-    skipWords = lodash.union(
+    globalSkipWords = lodash.union(
         ...getGloabalsSkipsWords(),
         defaultSettings.skipWords,
         Object.getOwnPropertyNames(String.prototype),
         Object.getOwnPropertyNames(JSON),
         Object.getOwnPropertyNames(Math)
-    );
+    ),
+    globalSkipWordsSet = new Set(globalSkipWords.map(function (string) {
+        return string.toLowerCase();
+    }));
 
 
 // ESLint 3 had "eslint.version" in context. ESLint 4 does not have one.
@@ -137,10 +140,9 @@ module.exports = {
             initializeDictionary(lang);
         }
 
-        options.skipWords = new Set(lodash.union(options.skipWords, skipWords)
-            .map(function (string) {
-                return string.toLowerCase();
-            }));
+        options.skipWords = new Set(options.skipWords.map(function (string) {
+            return string.toLowerCase();
+        }));
 
         options.skipIfMatch = lodash.union(options.skipIfMatch, defaultSettings.skipIfMatch);
 
@@ -153,8 +155,12 @@ module.exports = {
             spell.use(dictionary);
         }
 
+        function hasValueInSkipWords(value) {
+            return options.skipWords.has(value) || globalSkipWordsSet.has(value);
+        }
+
         function isSpellingError(aWord) {
-            return !options.skipWords.has(aWord) && !spell.check(aWord);
+            return !hasValueInSkipWords(aWord) && !spell.check(aWord);
         }
 
         function checkSpelling(aNode, value, spellingType) {
@@ -216,7 +222,7 @@ module.exports = {
         }
         /* Returns true if the string in value has to be skipped for spell checking */
         function hasToSkip(value) {
-            return options.skipWords.has(value) ||
+            return hasValueInSkipWords(value) ||
                 lodash.find(options.skipIfMatch, function (aPattern) {
                     return value.match(aPattern);
                 });

--- a/test/spell-checker.js
+++ b/test/spell-checker.js
@@ -66,6 +66,10 @@ ruleTester.run('spellcheck/spell-checker', rule, {
             code: 'var source = \'<div className="video-img">\'',
             options:[{skipIfMatch:['=".*"']}]
         },
+        {
+            code: "var foo = 'This shouldn\\'t fail and also \\'tsih\\''",
+            options: [{skipWordIfMatch: ["'[^']+'"]}],
+        },
     ],
     invalid: [
         {
@@ -166,7 +170,21 @@ ruleTester.run('spellcheck/spell-checker', rule, {
             code: 'var pack = require("webpack")',
             options:[{ignoreRequire:false}],
             errors: [
-                { message: 'You have a misspelled word: webpack on String'}]
-        }
+                { message: 'You have a misspelled word: webpack on String'}
+            ]
+        },
+        {
+            code: "var foo = 'This shouldn\\'t fail, but tsih should'",
+            errors: [
+                { message: 'You have a misspelled word: tsih on String'}
+            ]
+        },
+        {
+            code: "var foo = 'This shouldn\\'t fail and also \\'tsih\\', but this wod should'",
+            options: [{skipWordIfMatch: ["'[^']+'"]}],
+            errors: [
+                { message: 'You have a misspelled word: wod on String'}
+            ]
+        },
     ]
 });


### PR DESCRIPTION
Fixed issue with apostrophe in string making the entire word/sentence valid regardless of spell errors.

Possibly related: [https://github.com/aotaduy/eslint-plugin-spellcheck/issues/48](https://github.com/aotaduy/eslint-plugin-spellcheck/issues/48)