### PR TITLE
feat: Add  curly apostrophe to ignored characters

### DIFF
--- a/rules/spell-checker.js
+++ b/rules/spell-checker.js
@@ -160,7 +160,7 @@ module.exports = {
         function checkSpelling(aNode, value, spellingType) {
             if(!hasToSkip(value)) {
                 // Regular expression matches regexp metacharacters, and any special char
-                var regexp = /(\\[sSwdDB0nfrtv])|\\[0-7][0-7][0-7]|\\x[0-9A-F][0-9A-F]|\\u[0-9A-F][0-9A-F][0-9A-F][0-9A-F]|[^0-9a-zA-Z ']/g,
+                var regexp = /(\\[sSwdDB0nfrtv])|\\[0-7][0-7][0-7]|\\x[0-9A-F][0-9A-F]|\\u[0-9A-F][0-9A-F][0-9A-F][0-9A-F]|[^0-9a-zA-Z '’]/g,
                     nodeWords = value.replace(regexp, ' ')
                         .replace(/([A-Z])/g, ' $1').split(' '),
                     errors;


### PR DESCRIPTION
This PR allows the grammatically correct apostrophe `’` to be used like the other apostrophe `'`.