### PR TITLE
feat: implement spell check in separated by underscore words

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ Check Spelling inside identifiers
 "ignoreRequire": <<Boolean>>, default: false
 Exclude `require()` imports from spell-checking. Useful for excluding NPM package name false-positives.
 
+"ignoreUpperCaseUnderscore": <<Boolean>>, default: false
+Exclude checking uppercase words separated by an underscore. e.g., `SEARCH_CONDITIONS_LIMIT`
+
 "templates": <<Boolean>>, default: true
 Check Spelling inside ES6 templates you should enable parser options for ES6 features for this to work
 Refer to: [specifying-parser-options](http://eslint.org/docs/user-guide/configuring#specifying-parser-options)

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Check Spelling inside identifiers
 "ignoreRequire": <<Boolean>>, default: false
 Exclude `require()` imports from spell-checking. Useful for excluding NPM package name false-positives.
 
-"ignoreUpperCaseUnderscore": <<Boolean>>, default: false
+"enableUpperCaseUnderscoreCheck": <<Boolean>>, default: false
 Exclude checking uppercase words separated by an underscore. e.g., `SEARCH_CONDITIONS_LIMIT`
 
 "templates": <<Boolean>>, default: true

--- a/rules/spell-checker.js
+++ b/rules/spell-checker.js
@@ -73,6 +73,10 @@ module.exports = {
                         type: 'boolean',
                         default: false
                     },
+                    ignoreUpperCaseUnderscore: {
+                        type: 'boolean',
+                        default: false
+                    },
                     templates: {
                         type: 'boolean',
                         default: true
@@ -111,7 +115,6 @@ module.exports = {
                 additionalProperties: false
             }
         ]
-
     },
 
     // create (function) returns an object with methods that ESLint calls to “visit” nodes while traversing the abstract syntax tree (AST as defined by ESTree) of JavaScript code:
@@ -164,31 +167,31 @@ module.exports = {
         }
 
         function checkSpelling(aNode, value, spellingType) {
-            if(!hasToSkip(value)) {
+            if (!hasToSkip(value)) {
                 // Regular expression matches regexp metacharacters, and any special char
                 var regexp = /(\\[sSwdDB0nfrtv])|\\[0-7][0-7][0-7]|\\x[0-9A-F][0-9A-F]|\\u[0-9A-F][0-9A-F][0-9A-F][0-9A-F]|[^0-9a-zA-Z '’]/g,
                     nodeWords = value.replace(regexp, ' ')
-                        .replace(/([A-Z])/g, ' $1').split(' '),
+                    .replace(/([A-Z])/g, ' $1').split(' '),
                     errors;
                 errors = nodeWords
                     .filter(hasToSkipWord)
                     .filter(isSpellingError)
-                    .filter(function(aWord) {
-                      // Split words by numbers for special cases such as test12anything78variable and to include 2nd and 3rd ordinals
-                      // also for Proper names we convert to lower case in second pass.
+                    .filter(function (aWord) {
+                        // Split words by numbers for special cases such as test12anything78variable and to include 2nd and 3rd ordinals
+                        // also for Proper names we convert to lower case in second pass.
                         var splitByNumberWords = aWord.replace(/[0-9']/g, ' ').replace(/([A-Z])/g, ' $1').toLowerCase().split(' ');
                         return splitByNumberWords.some(isSpellingError);
                     })
-                    .forEach(function(aWord) {
+                    .forEach(function (aWord) {
                         context.report(
                             aNode,
                             'You have a misspelled word: {{word}} on {{spellingType}}', {
-                              word: aWord,
-                              spellingType: spellingType
-                        });
+                                word: aWord,
+                                spellingType: spellingType
+                            });
                     });
-                }
             }
+        }
 
         function isInImportDeclaration(aNode) {
             // @see https://buildmedia.readthedocs.org/media/pdf/esprima/latest/esprima.pdf
@@ -198,26 +201,39 @@ module.exports = {
             );
         }
 
-        function checkComment(aNode) {
-            if(options.comments) {
-                checkSpelling(aNode, aNode.value, 'Comment');
+        function underscoreParser(aNode, value, spellingType) {
+            if (options.ignoreUpperCaseUnderscore) {
+                checkSpelling(aNode, value, spellingType);
+            } else {
+                const hasUnderscore = value.split('_').length > 1;
+                const splitValues = value.split('_');
+                splitValues.forEach((word) => {
+                    checkSpelling(aNode, hasUnderscore ? word.toLowerCase() : word, spellingType);
+                })
             }
         }
 
-        function checkLiteral(aNode){
-            if(options.strings && typeof aNode.value === 'string' && !isInImportDeclaration(aNode)) {
-                checkSpelling(aNode, aNode.value, 'String');
+        function checkComment(aNode) {
+            if (options.comments) {
+                underscoreParser(aNode, aNode.value, 'Comment');
             }
         }
-        function checkTemplateElement(aNode){
-            if(options.templates && typeof aNode.value.raw === 'string' && !isInImportDeclaration(aNode)) {
-                checkSpelling(aNode, aNode.value.raw, 'Template');
+
+        function checkLiteral(aNode) {
+            if (options.strings && typeof aNode.value === 'string' && !isInImportDeclaration(aNode)) {
+                underscoreParser(aNode, aNode.value, 'String');
+            }
+        }
+
+        function checkTemplateElement(aNode) {
+            if (options.templates && typeof aNode.value.raw === 'string' && !isInImportDeclaration(aNode)) {
+                underscoreParser(aNode, aNode.value.raw, 'Template');
             }
         }
 
         function checkIdentifier(aNode) {
-            if(options.identifiers) {
-                checkSpelling(aNode, aNode.name, 'Identifier');
+            if (options.identifiers) {
+                underscoreParser(aNode, aNode.name, 'Identifier');
             }
         }
         /* Returns true if the string in value has to be skipped for spell checking */

--- a/rules/spell-checker.js
+++ b/rules/spell-checker.js
@@ -73,7 +73,7 @@ module.exports = {
                         type: 'boolean',
                         default: false
                     },
-                    ignoreUpperCaseUnderscore: {
+                    enableUpperCaseUnderscoreCheck: {
                         type: 'boolean',
                         default: false
                     },
@@ -202,13 +202,12 @@ module.exports = {
         }
 
         function underscoreParser(aNode, value, spellingType) {
-            if (options.ignoreUpperCaseUnderscore) {
+            if (!options.enableUpperCaseUnderscoreCheck) {
                 checkSpelling(aNode, value, spellingType);
             } else {
-                const hasUnderscore = value.split('_').length > 1;
                 const splitValues = value.split('_');
                 splitValues.forEach((word) => {
-                    checkSpelling(aNode, hasUnderscore ? word.toLowerCase() : word, spellingType);
+                    checkSpelling(aNode, word.toLowerCase(), spellingType);
                 })
             }
         }

--- a/test/spell-checker.js
+++ b/test/spell-checker.js
@@ -44,6 +44,16 @@ ruleTester.run('spellcheck/spell-checker', rule, {
         'var url = "http://examplus.com"',
         'var a = Math.trunc(-0.1)',
         'var a = "test", test = `${a}`;',
+        'var a = "ADD_SUM";',
+        'const SEARCH_CONDITIONS_LIMIT = 9;',
+        {
+            code: 'var a = "ADD_SMU"',
+            options:[{ ignoreUpperCaseUnderscore: true }]
+        },
+        {
+            code: 'const SEACH_CONDITIONS_LIMIT = 9;',
+            options:[{ ignoreUpperCaseUnderscore: true }]
+        },
         {
             code: 'var a = 1 // This is a comment',
             options: [{lang: 'sym', langDir: __dirname}]
@@ -183,7 +193,15 @@ ruleTester.run('spellcheck/spell-checker', rule, {
             errors: [
                 { message: 'You have a misspelled word: noooot on Template'}]
         },
-
-
+        {
+            code: 'var a = "ADD_SMU"',
+            errors: [
+                { message: 'You have a misspelled word: smu on String'}]
+        },
+        {
+            code: 'const SEACH_CONDITIONS_LIMIT = 9;',
+            errors: [
+                { message: 'You have a misspelled word: seach on Identifier'}]
+        },
     ]
 });

--- a/test/spell-checker.js
+++ b/test/spell-checker.js
@@ -15,10 +15,10 @@ var ruleTester = new RuleTester({
     },
 
     parserOptions: {
-      "ecmaVersion": 2018,
-      "sourceType": "module",
+      'ecmaVersion': 2018,
+      'sourceType': 'module',
         ecmaFeatures: {
-            "modules": true
+            'modules': true
         }
     }
 });
@@ -45,15 +45,13 @@ ruleTester.run('spellcheck/spell-checker', rule, {
         'var a = Math.trunc(-0.1)',
         'var a = "test", test = `${a}`;',
         'var a = "ADD_SUM";',
+        'var a = "ADD_SMU";',
         'const SEARCH_CONDITIONS_LIMIT = 9;',
-        {
-            code: 'var a = "ADD_SMU"',
-            options:[{ ignoreUpperCaseUnderscore: true }]
-        },
-        {
-            code: 'const SEACH_CONDITIONS_LIMIT = 9;',
-            options:[{ ignoreUpperCaseUnderscore: true }]
-        },
+        'const SEACH_CONDITIONS_LIMIT = 9;',
+        'const KEY = "HELLO_WORLD";',
+        'const KEY = "HELLO_WORDL";',
+        'const PASSWORD = "123456";',
+        'const PASSWROD = "123456";',
         {
             code: 'var a = 1 // This is a comment',
             options: [{lang: 'sym', langDir: __dirname}]
@@ -195,13 +193,27 @@ ruleTester.run('spellcheck/spell-checker', rule, {
         },
         {
             code: 'var a = "ADD_SMU"',
+            options:[{ enableUpperCaseUnderscoreCheck: true }],
             errors: [
                 { message: 'You have a misspelled word: smu on String'}]
         },
         {
             code: 'const SEACH_CONDITIONS_LIMIT = 9;',
+            options:[{ enableUpperCaseUnderscoreCheck: true }],
             errors: [
                 { message: 'You have a misspelled word: seach on Identifier'}]
+        },
+        {
+            code: 'const KEY = "HELLO_WORDL";',
+            options:[{ enableUpperCaseUnderscoreCheck: true }],
+            errors: [
+                { message: 'You have a misspelled word: wordl on String'}]
+        },
+        {
+            code: 'const PASSWROD = "123456";',
+            options:[{ enableUpperCaseUnderscoreCheck: true }],
+            errors: [
+                { message: 'You have a misspelled word: passwrod on Identifier'}]
         },
     ]
 });


### PR DESCRIPTION
## Describe

Hello @aotaduy 

According to this [PR](https://github.com/aotaduy/eslint-plugin-spellcheck/pull/17), I implemented the `underscoreParser` function to check the uppercase word separated by an underscore, hoping you could take some time to review and release the new version to npm.

## Changes
- Add new config `ignoreUpperCaseUnderscore` description in the `README.md ` file.
- Implemented the `underscoreParser` function in the `rules/spell-checker.js` file.
- Add some unit tests in the `test/spell-checker.js` file.